### PR TITLE
Fix item handler

### DIFF
--- a/code/Modules/Items/Instances/Item.cs
+++ b/code/Modules/Items/Instances/Item.cs
@@ -11,7 +11,7 @@ namespace ssl.Modules.Items.Instances;
 ///     It is both the item in inventory and the world entity.
 ///     This class is used clientside and server side so properties useful clientside should be [Net].
 /// </summary>
-public class Item : Carriable, IDraggable
+public partial class Item : Carriable, IDraggable
 {
 	public const string TAG = "Item";
 
@@ -24,11 +24,10 @@ public class Item : Carriable, IDraggable
 		GlowColor = Color.Blue;
 	}
 
-	public string Id { get; set; }
-
-	public string Description { get; set; }
-	public string WasteId { get; set; }
-	public HoldType HoldType { get; set; }
+	[Net] public string Id { get; set; }
+	[Net] public string Description { get; set; }
+	[Net] public string WasteId { get; set; }
+	[Net] public HoldType HoldType { get; set; }
 
 	public void OnSelectStart( SslPlayer sslPlayer )
 	{

--- a/code/Modules/Items/ItemDao.cs
+++ b/code/Modules/Items/ItemDao.cs
@@ -59,7 +59,7 @@ public class ItemDao : LocalDao<ItemData>
 			Name = "Pistol",
 			Description = "A pistol",
 			Model = "weapons/rust_pistol/rust_pistol.vmdl",
-			HoldType = HoldType.Hand,
+			HoldType = HoldType.Pistol,
 			PrimaryRate = 5.0f,
 			Damage = 10.0f,
 			Range = 0.0f, // Infinite


### PR DESCRIPTION
**Issue**: We couldn't see the pistol in hands

**Reason**: The item properties wasn't networked and so the HoldType property wasn't replicated client side, staying to the default HoldType.None instead of Pistol

**Fix**: Added [Net] to all properties of Item

NB: This maybe should be replicated onto other systems